### PR TITLE
Transparent overwrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+test-chart

--- a/transparent-overwrite-example-chart/.helmignore
+++ b/transparent-overwrite-example-chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/transparent-overwrite-example-chart/Chart.yaml
+++ b/transparent-overwrite-example-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: transparent-overwrite-example-chart
+version: 0.1.0

--- a/transparent-overwrite-example-chart/templates/deployment.tpl
+++ b/transparent-overwrite-example-chart/templates/deployment.tpl
@@ -1,0 +1,30 @@
+{{- /* Current Aproach */}}
+
+{{- $serviceValues := dict "Values" .Values.authWs }}
+{{- $commonValues := dict "Values" .Values.common }}
+{{- $values := merge $serviceValues $commonValues }}
+
+{{ include "deployment" $values }}
+
+{{- define "deployment" }}
+  appName: {{ .Values.appName }}
+  predefinedAppName: {{ .Values.predefinedAppName }}
+  environment: {{ .Values.environment }}
+  memorySpecificJavaOpts: {{ .Values.memorySpecificJavaOpts }}
+{{- end }}
+
+----------------------------------------
+{{- /* Alternative (Strict) Aproach */}}
+
+{{- $serviceValues1 := dict "Values" .Values.authWs }}
+{{- $commonValues1 := dict "Values" (dict "common" .Values.common) }}
+{{- $values1 := merge $serviceValues1 $commonValues1 }}
+
+{{ include "alternative-deployment" $values1 }}
+
+{{- define "alternative-deployment" }}
+  appName: {{ .Values.appName }}
+  predefinedAppName: {{ .Values.common.predefinedAppName }}
+  environment: {{ .Values.common.environment }}
+  memorySpecificJavaOpts: {{ .Values.common.memorySpecificJavaOpts }}
+{{- end }}

--- a/transparent-overwrite-example-chart/values.yaml
+++ b/transparent-overwrite-example-chart/values.yaml
@@ -1,0 +1,10 @@
+authWs:
+  appName: auth-ws
+  environment: nonsense
+
+
+common:
+  predefinedAppName: nonsense
+  environment: staging
+  memorySpecificJavaOpts: >-
+    -XX:MaxRAMFraction=2


### PR DESCRIPTION
The important files here are `values.yaml` and `deployment.tpl`

See how the values are put into the template when you run 
```
helm install transparent-overwrite-example-chart --dry-run --debug
```



In order to reuse templates between services we do not want to reference values by their full key
(e.g. `.Values.authWs.key`) but we want to omit the service specific part (i.e. `.Values.key`).

Currently we enable transparent overwriting of values in a way that `.Values.key` can be used to point to a value defined in `authWs.key` or `common.key`, where `authWs.key` has precedence over `common.key` in case that both are defined.

In the alternative (strict) approach `.Values.key` points to the value defined in `.Values.authWs.key` but NOT to `.Values.common.key`. If we want to point to a common/shared value it needs to be explicitly done with `Values.common.key`.